### PR TITLE
Apportare modifiche al progetto

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -154,6 +154,13 @@ service cloud.firestore {
       allow write: if isAuthenticated() && hasPermission('manage_dipendenti');
     }
     
+    // 💼 Centri di costo (cantieri e mansioni interne)
+    match /centri_costo/{centroId} {
+      allow read: if isAuthenticated();
+      // Gestione consentita a admin e manager
+      allow write: if isAuthenticated() && (hasRoleLevel(80) || isAdmin());
+    }
+    
     // 💰 Fatture
     match /fatture/{fatturaId} {
       allow read: if isAuthenticated() && hasPermission('view_fatture');

--- a/src/config/firebase.js
+++ b/src/config/firebase.js
@@ -89,6 +89,8 @@ export const firestoreConfig = {
     dipendenti: 'dipendenti',
     timesheet: 'timesheet',
     presenze: 'presenze',
+    // 💼 Centri di costo (Cantieri e Mansioni interne)
+    centriCosto: 'centri_costo',
     
     // 🚚 Gestione fornitori e mezzi
     fornitori: 'fornitori',

--- a/src/scripts/seedCentriCosto.js
+++ b/src/scripts/seedCentriCosto.js
@@ -1,0 +1,27 @@
+import { db } from '@/config/firebase'
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore'
+
+// Esegui manualmente da console:
+// import('/src/scripts/seedCentriCosto.js').then(m => m.seedCentriCosto())
+
+export const seedCentriCosto = async () => {
+  const seed = [
+    { nome: 'Riparazioni', tipo: 'MANSIONE' },
+    { nome: 'Commerciale', tipo: 'MANSIONE' },
+    { nome: 'Magazzino', tipo: 'MANSIONE' },
+    { nome: 'Consegne', tipo: 'MANSIONE' },
+    { nome: 'Amministrazione', tipo: 'MANSIONE' }
+  ]
+
+  const col = collection(db, 'centri_costo')
+  let created = 0
+  for (const item of seed) {
+    await addDoc(col, { ...item, stato: 'attivo', createdAt: serverTimestamp() })
+    created++
+  }
+  console.log(`✅ Seed centri_costo completato: ${created} voci create`)
+  return { success: true, created }
+}
+
+export default seedCentriCosto
+

--- a/src/stores/firestore.js
+++ b/src/stores/firestore.js
@@ -44,6 +44,9 @@ export const useFirestoreStore = defineStore('firestore', () => {
   const dipendenti = ref([])
   const timesheet = ref([])
   const presenze = ref([])
+
+  // 💼 Centri di costo (cantieri o mansioni)
+  const centriCosto = ref([])
   
   // 🚚 Fornitori
   const fornitori = ref([])
@@ -362,6 +365,32 @@ export const useFirestoreStore = defineStore('firestore', () => {
     }
     
     return await createDocument(firestoreConfig.collections.cantieri, data)
+  }
+
+  // 💼 Metodi per Centri di Costo
+  const loadCentriCosto = async () => {
+    const result = await loadCollection(firestoreConfig.collections.centriCosto)
+    if (result.success) {
+      centriCosto.value = result.data
+    }
+    return result
+  }
+
+  const createCentroCosto = async (centroData) => {
+    const data = {
+      ...centroData,
+      tipo: centroData.tipo || 'MANSIONE', // 'CANTIERE' o 'MANSIONE'
+      stato: centroData.stato || 'attivo'
+    }
+    return await createDocument(firestoreConfig.collections.centriCosto, data)
+  }
+
+  const updateCentroCosto = async (centroId, updateData) => {
+    return await updateDocument(firestoreConfig.collections.centriCosto, centroId, updateData)
+  }
+
+  const archiveCentroCosto = async (centroId) => {
+    return await updateDocument(firestoreConfig.collections.centriCosto, centroId, { stato: 'archiviato' })
   }
 
   const updateCantiereProgress = async (cantiereId, progressData) => {
@@ -1166,6 +1195,7 @@ export const useFirestoreStore = defineStore('firestore', () => {
     // State
     loading,
     error,
+    centriCosto,
     cantieri,
     cantieriProgress,
     clienti,
@@ -1200,6 +1230,12 @@ export const useFirestoreStore = defineStore('firestore', () => {
     loadCantieri,
     createCantiere,
     updateCantiereProgress,
+
+    // Centri di costo
+    loadCentriCosto,
+    createCentroCosto,
+    updateCentroCosto,
+    archiveCentroCosto,
     
     // Clienti
     loadClienti,

--- a/src/views/Personale.vue
+++ b/src/views/Personale.vue
@@ -564,6 +564,23 @@
                 </p>
               </div>
               
+              <!-- Centro di costo -->
+              <div class="text-left">
+                <p class="text-sm text-gray-500 mb-1">Centro di costo</p>
+                <select
+                  v-model="presenze[dipendente.id].centroSelezionato"
+                  class="w-56 px-3 py-2 border border-gray-300 rounded text-base focus:ring-primary-500 focus:border-primary-500"
+                >
+                  <option value="">Seleziona...</option>
+                  <optgroup label="Cantieri">
+                    <option v-for="opt in cantieriOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                  </optgroup>
+                  <optgroup label="Mansioni">
+                    <option v-for="opt in mansioniOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                  </optgroup>
+                </select>
+              </div>
+              
               <!-- Stato presenza -->
               <div class="text-center">
                 <p class="text-sm text-gray-500 mb-1">Stato</p>
@@ -646,6 +663,21 @@
                   <option value="ferie">Ferie</option>
                   <option value="malattia">Malattia</option>
                   <option value="permesso">Permesso</option>
+                </select>
+              </div>
+              <div class="col-span-2">
+                <label class="block text-sm text-gray-500 mb-1">Centro di costo</label>
+                <select
+                  v-model="presenze[dipendente.id].centroSelezionato"
+                  class="w-full px-4 py-3 border border-gray-300 rounded-lg text-base focus:ring-primary-500 focus:border-primary-500"
+                >
+                  <option value="">Seleziona...</option>
+                  <optgroup label="Cantieri">
+                    <option v-for="opt in cantieriOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                  </optgroup>
+                  <optgroup label="Mansioni">
+                    <option v-for="opt in mansioniOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+                  </optgroup>
                 </select>
               </div>
             </div>
@@ -2495,7 +2527,8 @@ const loadPresenze = async () => {
             entrata: '',
             uscita: '',
             pausa: 0,
-            note: ''
+            note: '',
+            centroSelezionato: ''
           }
         }
       })
@@ -2607,7 +2640,16 @@ const savePresenza = async (dipendenteId) => {
         data: selectedDate.value,
         ore: ore,
         oreLavorate: ore,
-        cantiere: dipendente.cantiereAttuale || 'Sede',
+        // Centro di costo derivato dalla presenza (selezione giornaliera)
+        cantiere: (() => {
+          const sel = presenzaData.centroSelezionato || ''
+          const tipo = sel.split(':')[0]
+          const label = sel.split(':')[2]
+          return tipo === 'CANTIERE' ? (label || dipendente.cantiereAttuale || 'Sede') : undefined
+        })(),
+        centroCostoId: (() => (presenzaData.centroSelezionato || '').split(':')[1] || null)(),
+        centroCostoNome: (() => (presenzaData.centroSelezionato || '').split(':')[2] || null)(),
+        centroCostoTipo: (() => (presenzaData.centroSelezionato || '').split(':')[0] || null)(),
         note: `Generato da presenze: ${presenzaData.note || ''}`,
         costoOrario: dipendente.pagaOraria || 25,
         costoTotale: ore * (dipendente.pagaOraria || 25),


### PR DESCRIPTION
Introduce 'Centri di costo' to enable assigning working hours to internal tasks (Mansioni) alongside existing construction sites (Cantieri).

This PR lays the groundwork for the 'Centri di costo' feature, unifying work destinations. It includes schema updates, Firestore rules, store logic, and a seed script for initial 'Mansioni' (Riparazioni, Commerciale, Magazzino, Consegne, Amministrazione), preparing the backend for future UI integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa5e1db6-bb33-45bd-a899-b2b257d27784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa5e1db6-bb33-45bd-a899-b2b257d27784">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

